### PR TITLE
Install dev dependencies in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .  # Install package with CLI tools
+          pip install -e ".[dev]"  # Install package with CLI tools and dev dependencies (pytest)
 
       - name: Run tests
         run: pytest -v --tb=short


### PR DESCRIPTION
- Changed from 'pip install -e .' to 'pip install -e ".[dev]"'
- Installs pytest and other dev dependencies from pyproject.toml
- Fixes 'pytest: command not found' error