### PR TITLE
Update all tests to use new package structure

### DIFF
--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -319,7 +319,7 @@ class TestValidator:
 
     def test_validates_minimum_course_count(self):
         """Test that validator warns on low course count."""
-        from validator import CourseDataValidator
+        from dtu_analyzer.validation.validator import CourseDataValidator
 
         # Less than MIN_COURSES
         data = {f"{i:05d}": {"name": f"Course {i}"} for i in range(100)}
@@ -330,7 +330,7 @@ class TestValidator:
 
     def test_validates_course_id_format(self):
         """Test course ID validation."""
-        from validator import CourseDataValidator
+        from dtu_analyzer.validation.validator import CourseDataValidator
 
         data = {"abc": {"name": "Bad ID"}, "12345": {"name": "Good ID"}}
         validator = CourseDataValidator(data)
@@ -341,7 +341,7 @@ class TestValidator:
 
     def test_validates_grade_structure(self):
         """Test grade data validation."""
-        from validator import CourseDataValidator
+        from dtu_analyzer.validation.validator import CourseDataValidator
 
         data = {
             "12345": {
@@ -358,7 +358,7 @@ class TestValidator:
 
     def test_catches_invalid_participants(self):
         """Test that invalid participants values are caught."""
-        from validator import CourseDataValidator
+        from dtu_analyzer.validation.validator import CourseDataValidator
 
         data = {
             "12345": {
@@ -375,7 +375,7 @@ class TestValidator:
 
     def test_catches_out_of_range_pass_percentage(self):
         """Test that out-of-range pass percentage is caught."""
-        from validator import CourseDataValidator
+        from dtu_analyzer.validation.validator import CourseDataValidator
 
         data = {
             "12345": {
@@ -392,7 +392,7 @@ class TestValidator:
 
     def test_get_summary(self):
         """Test summary generation."""
-        from validator import CourseDataValidator
+        from dtu_analyzer.validation.validator import CourseDataValidator
 
         data = {"12345": {"name": "Test Course"}}
         validator = CourseDataValidator(data)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -10,7 +10,7 @@ import os
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from scraper import (
+from dtu_analyzer.scrapers.threaded_scraper import (
     removeWhitespace,
     parse_year,
     Course,
@@ -142,7 +142,7 @@ class TestRespObj:
 class TestExtractGrades:
     """Tests for the Course.extractGrades method."""
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_returns_false_when_no_html(self, mock_resp):
         mock_resp.return_value = False
 
@@ -151,7 +151,7 @@ class TestExtractGrades:
 
         assert result is False
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_returns_false_when_not_enough_tables(self, mock_resp):
         mock_resp.return_value = "<html><body><table></table></body></html>"
 
@@ -160,7 +160,7 @@ class TestExtractGrades:
 
         assert result is False
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_extracts_timestamp_from_url(self, mock_resp):
         # Mock HTML with 3 tables (minimum required)
         html = """
@@ -190,7 +190,7 @@ class TestExtractGrades:
 class TestExtractReviews:
     """Tests for the Course.extractReviews method."""
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_returns_false_when_no_html(self, mock_resp):
         mock_resp.return_value = False
 
@@ -199,7 +199,7 @@ class TestExtractReviews:
 
         assert result is False
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_returns_false_when_no_public_container(self, mock_resp):
         mock_resp.return_value = "<html><body><div>No reviews here</div></body></html>"
 
@@ -218,7 +218,7 @@ class TestGather:
         result = course.gather()
         assert result is False
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_returns_dict_when_grades_found(self, mock_resp):
         # Mock HTML with proper structure
         html = """
@@ -250,18 +250,18 @@ class TestGather:
 class TestProcessSingleCourse:
     """Tests for the process_single_course function."""
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_returns_none_when_no_overview(self, mock_resp):
-        from scraper import process_single_course
+        from dtu_analyzer.scrapers.threaded_scraper import process_single_course
         mock_resp.return_value = False
 
         result = process_single_course("12345")
 
         assert result is None
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_returns_none_when_no_links_found(self, mock_resp):
-        from scraper import process_single_course
+        from dtu_analyzer.scrapers.threaded_scraper import process_single_course
         # Return HTML with no grade/review links
         mock_resp.return_value = "<html><body><a href='/other'>Other</a></body></html>"
 
@@ -269,10 +269,10 @@ class TestProcessSingleCourse:
 
         assert result is None
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_fetches_danish_name_with_lang_parameter(self, mock_resp):
         """Test that Danish course name is fetched with ?lang=da-DK parameter."""
-        from scraper import process_single_course, BASE_URL
+        from dtu_analyzer.scrapers.threaded_scraper import process_single_course, BASE_URL
 
         # Track all URLs that respObj is called with
         called_urls = []
@@ -308,10 +308,10 @@ class TestProcessSingleCourse:
         english_url = f"{BASE_URL}/course/12345?lang=en-GB"
         assert english_url in called_urls, f"Expected {english_url} in {called_urls}"
 
-    @patch('scraper.respObj')
+    @patch('dtu_analyzer.scrapers.threaded_scraper.respObj')
     def test_stores_different_danish_and_english_names(self, mock_resp):
         """Test that Danish and English names are stored separately and can differ."""
-        from scraper import process_single_course, BASE_URL
+        from dtu_analyzer.scrapers.threaded_scraper import process_single_course, BASE_URL
 
         def return_language_specific_html(url, sess=None):
             # Return minimal valid HTML for overview page
@@ -355,6 +355,6 @@ class TestMain:
 
     @patch('builtins.open', side_effect=FileNotFoundError())
     def test_returns_error_when_coursenumbers_missing(self, mock_open):
-        from scraper import main
+        from dtu_analyzer.scrapers.threaded_scraper import main
         result = main()
         assert result == 1

--- a/tests/validate_pipeline.py
+++ b/tests/validate_pipeline.py
@@ -261,32 +261,6 @@ def test_config_paths():
     print("✅ Configuration paths work correctly\n")
 
 
-def test_backward_compatibility():
-    """Test that old import paths still work."""
-    print("="*60)
-    print("Testing: Backward Compatibility")
-    print("="*60)
-
-    # Test old scraper imports
-    import scraper
-    import scraper_async
-    import analyzer
-    import validator
-
-    assert hasattr(scraper, 'main')
-    assert hasattr(scraper_async, 'main')
-    assert hasattr(analyzer, 'main')
-    assert hasattr(validator, 'main')
-
-    print("✓ Old import paths work:")
-    print("  - scraper.py → src.dtu_analyzer.scrapers.threaded_scraper")
-    print("  - scraper_async.py → src.dtu_analyzer.scrapers.async_scraper")
-    print("  - analyzer.py → src.dtu_analyzer.analysis.analyzer")
-    print("  - validator.py → src.dtu_analyzer.validation.validator")
-
-    print("✅ Backward compatibility verified\n")
-
-
 def main():
     """Run all pipeline validation tests."""
     print("\n" + "="*60)
@@ -299,7 +273,6 @@ def main():
         test_parser_pipeline()
         test_validation_pipeline()
         test_analysis_pipeline()
-        test_backward_compatibility()
 
         print("="*60)
         print("🎉 ALL PIPELINE TESTS PASSED!")
@@ -309,7 +282,6 @@ def main():
         print("✅ Parser modules process data correctly")
         print("✅ Validation pipeline detects data quality issues")
         print("✅ Analysis pipeline calculates metrics and percentiles")
-        print("✅ Backward compatibility maintained")
         print("\nThe refactored codebase is production-ready!")
         print("="*60 + "\n")
 

--- a/tests/validate_refactor.py
+++ b/tests/validate_refactor.py
@@ -214,20 +214,6 @@ def test_threaded_scraper():
     print(f"   Threaded scraper imported successfully")
 
 
-@test("Step 5: Backward compatibility (scrapers)")
-def test_scraper_wrappers():
-    """Test backward-compatible scraper wrappers."""
-    # Test async scraper wrapper
-    import scraper_async
-    assert hasattr(scraper_async, 'main'), "scraper_async wrapper missing main"
-
-    # Test threaded scraper wrapper
-    import scraper
-    assert hasattr(scraper, 'main'), "scraper wrapper missing main"
-
-    print(f"   Scraper wrappers work correctly")
-
-
 @test("Step 6: Analysis module")
 def test_analyzer():
     """Test analyzer module can be imported."""
@@ -283,20 +269,6 @@ def test_validator():
     print(f"   Validator imported and tested successfully")
 
 
-@test("Step 6: Backward compatibility (analysis/validation)")
-def test_analysis_validation_wrappers():
-    """Test backward-compatible wrappers for analyzer and validator."""
-    # Test analyzer wrapper
-    import analyzer
-    assert hasattr(analyzer, 'main'), "analyzer wrapper missing main"
-
-    # Test validator wrapper
-    import validator
-    assert hasattr(validator, 'main'), "validator wrapper missing main"
-
-    print(f"   Analysis/validation wrappers work correctly")
-
-
 @test("Integration: Full import chain")
 def test_full_import_chain():
     """Test that all modules can be imported together without conflicts."""
@@ -312,12 +284,6 @@ def test_full_import_chain():
     from src.dtu_analyzer.scrapers.threaded_scraper import main as threaded_main
     from src.dtu_analyzer.analysis.analyzer import main as analyze_main
     from src.dtu_analyzer.validation.validator import main as validate_main
-
-    # Also import wrappers
-    import scraper
-    import scraper_async
-    import analyzer
-    import validator
 
     print(f"   All modules imported successfully")
     print(f"   Package version: {__version__}")
@@ -339,10 +305,8 @@ def main():
     test_review_parser()
     test_async_scraper()
     test_threaded_scraper()
-    test_scraper_wrappers()
     test_analyzer()
     test_validator()
-    test_analysis_validation_wrappers()
     test_full_import_chain()
 
     # Print summary


### PR DESCRIPTION
- Updated test_scraper.py: Changed imports from 'scraper' to 'dtu_analyzer.scrapers.threaded_scraper'
- Updated test_analyzer.py: Changed imports from 'validator' to 'dtu_analyzer.validation.validator'
- Updated validate_refactor.py: Removed backward compatibility tests for deleted wrapper files
- Updated validate_pipeline.py: Removed backward compatibility tests for deleted wrapper files

All tests now import directly from the new package structure instead of wrapper files.