### PR TITLE
Fix workflow to only commit extension files

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -57,4 +57,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Auto-update course data [skip ci]"
-          file_pattern: "extension/db/data.js data/data.json data/coursedic.json data/coursenumbers.txt extension/db.html"
+          file_pattern: "extension/db/data.js extension/db.html extension/js/init_table.js"


### PR DESCRIPTION
The workflow was trying to commit data files (coursedic.json, data.json, coursenumbers.txt) that are intentionally ignored by .gitignore. These are large generated files that shouldn't be in the repository.

Changed file_pattern to only commit the processed extension files:
- extension/db/data.js (processed course data)
- extension/db.html (generated HTML table)
- extension/js/init_table.js (table initialization)

The raw scraped data stays in data/ directory locally but is not committed.