### PR TITLE
feat: weekly DTU course-data change detector

### DIFF
--- a/.github/workflows/check-course-updates.yml
+++ b/.github/workflows/check-course-updates.yml
@@ -70,26 +70,38 @@ jobs:
           fi
           python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
           import json, pathlib
-          r = json.loads(pathlib.Path("check_report.json").read_text())
-          course_base = r.get('course_info_base_url', 'http://kurser.dtu.dk/course')
+
           print("## DTU course-data check")
           print()
-          print(f"- Checked at: `{r['checked_at']}`")
-          print(f"- Baseline courses: {r['baseline_course_count']} | Current: {r['current_course_count']}")
+          try:
+              r = json.loads(pathlib.Path("check_report.json").read_text())
+          except Exception as e:
+              print(f"Could not read `check_report.json`: `{e}`")
+              raise SystemExit(0)
+
+          course_base = r.get('course_info_base_url', 'http://kurser.dtu.dk/course')
+          print(f"- Checked at: `{r.get('checked_at', 'unknown')}`")
+          print(f"- Baseline courses: {r.get('baseline_course_count', 0)} | Current: {r.get('current_course_count', 0)}")
           print(f"- Courses probed for semester links: {r.get('probed_course_count', r.get('sample_size', 0))}")
-          print(f"- **Changes detected: {r['has_changes']}**")
+          print(f"- **Changes detected: {r.get('has_changes', False)}**")
+          if r.get('baseline_missing'):
+              print("- **Baseline missing:** course-list diff suppressed")
+          if r.get('probe_error'):
+              print(f"- **Probe error:** `{r['probe_error']}`")
+          if r.get('failure_reason'):
+              print(f"- **Failure reason:** `{r['failure_reason']}`")
           print()
-          if r['added_courses']:
+          if r.get('added_courses'):
               print(f"### Added courses ({len(r['added_courses'])})")
               for c in r['added_courses']:
                   print(f"- [{c}]({course_base}/{c}/info)")
               print()
-          if r['removed_courses']:
+          if r.get('removed_courses'):
               print(f"### Removed courses ({len(r['removed_courses'])})")
               for c in r['removed_courses']:
                   print(f"- [{c}]({course_base}/{c}/info)")
               print()
-          if r['new_semesters']:
+          if r.get('new_semesters'):
               print(f"### New grade semesters ({len(r['new_semesters'])})")
               for s in r['new_semesters']:
                   print(f"- [{s['course']} → {s['url']}]({s['url']})")
@@ -97,7 +109,7 @@ jobs:
           PY
 
       - name: Open or update tracking issue
-        if: success()
+        if: always()
         uses: actions/github-script@v7
         env:
           REPORT_PATH: check_report.json
@@ -109,7 +121,13 @@ jobs:
               core.info('No report file; nothing to do.');
               return;
             }
-            const report = JSON.parse(fs.readFileSync(path, 'utf8'));
+            let report;
+            try {
+              report = JSON.parse(fs.readFileSync(path, 'utf8'));
+            } catch (e) {
+              core.warning(`Could not parse report: ${e}`);
+              return;
+            }
             if (!report.has_changes) {
               core.info('No changes detected; not opening an issue.');
               return;
@@ -151,6 +169,8 @@ jobs:
             lines.push('');
             lines.push(`- Baseline courses: **${report.baseline_course_count}** · Current: **${report.current_course_count}**`);
             lines.push(`- Courses probed for semester links: **${report.probed_course_count ?? report.sample_size ?? 0}**`);
+            if (report.probe_error) lines.push(`- Probe error: \`${report.probe_error}\``);
+            if (report.baseline_missing) lines.push('- Baseline missing: course-list diff suppressed');
             lines.push('');
             if (added.length) {
               lines.push(`### Added courses (${added.length})`);

--- a/.github/workflows/check-course-updates.yml
+++ b/.github/workflows/check-course-updates.yml
@@ -1,0 +1,201 @@
+name: Check for Course Data Updates
+
+on:
+  schedule:
+    # 07:00 UTC Sunday ≈ 09:00 Copenhagen (CEST in summer / 08:00 CET in winter)
+    - cron: '0 7 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12.3'
+          cache: 'pip'
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: playwright install chromium
+
+      - name: Authenticate and get cookie
+        env:
+          DTU_USERNAME: ${{ secrets.DTU_USERNAME }}
+          DTU_PASSWORD: ${{ secrets.DTU_PASSWORD }}
+        run: dtu-auth
+
+      - name: Run update check
+        run: dtu-check-updates
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: check-report
+          path: check_report.json
+          if-no-files-found: warn
+
+      - name: Write summary
+        if: always()
+        run: |
+          if [ ! -f check_report.json ]; then
+            echo "## DTU course-data check" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No report file produced — see logs." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, pathlib
+          r = json.loads(pathlib.Path("check_report.json").read_text())
+          print("## DTU course-data check")
+          print()
+          print(f"- Checked at: `{r['checked_at']}`")
+          print(f"- Baseline courses: {r['baseline_course_count']} | Current: {r['current_course_count']}")
+          print(f"- Sample size for semester probe: {r['sample_size']}")
+          print(f"- **Changes detected: {r['has_changes']}**")
+          print()
+          if r['added_courses']:
+              print(f"### Added courses ({len(r['added_courses'])})")
+              for c in r['added_courses']:
+                  print(f"- [{c}](http://kurser.dtu.dk/course/{c}/info)")
+              print()
+          if r['removed_courses']:
+              print(f"### Removed courses ({len(r['removed_courses'])})")
+              for c in r['removed_courses']:
+                  print(f"- [{c}](http://kurser.dtu.dk/course/{c}/info)")
+              print()
+          if r['new_semesters']:
+              print(f"### New grade semesters ({len(r['new_semesters'])})")
+              for s in r['new_semesters']:
+                  print(f"- [{s['course']} → {s['url']}]({s['url']})")
+              print()
+          PY
+
+      - name: Open or update tracking issue
+        if: success()
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: check_report.json
+        with:
+          script: |
+            const fs = require('fs');
+            const path = process.env.REPORT_PATH;
+            if (!fs.existsSync(path)) {
+              core.info('No report file; nothing to do.');
+              return;
+            }
+            const report = JSON.parse(fs.readFileSync(path, 'utf8'));
+            if (!report.has_changes) {
+              core.info('No changes detected; not opening an issue.');
+              return;
+            }
+
+            const label = 'course-data-update';
+            // Ensure the label exists.
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: 'fbca04',
+                  description: 'DTU has new course data — verify and trigger Update Course Data workflow.',
+                });
+              } else {
+                throw e;
+              }
+            }
+
+            const date = report.checked_at.slice(0, 10);
+            const added = report.added_courses || [];
+            const removed = report.removed_courses || [];
+            const semesters = report.new_semesters || [];
+
+            const title = `Weekly check: ${added.length} new course(s), ` +
+                          `${removed.length} removed, ${semesters.length} new semester(s) (${date})`;
+
+            const lines = [];
+            lines.push(`Automated weekly check detected new data on kurser.dtu.dk at \`${report.checked_at}\`.`);
+            lines.push('');
+            lines.push(`- Baseline courses: **${report.baseline_course_count}** · Current: **${report.current_course_count}**`);
+            lines.push(`- Sample size for semester probe: **${report.sample_size}**`);
+            lines.push('');
+            if (added.length) {
+              lines.push(`### Added courses (${added.length})`);
+              for (const c of added) lines.push(`- [\`${c}\`](http://kurser.dtu.dk/course/${c}/info)`);
+              lines.push('');
+            }
+            if (removed.length) {
+              lines.push(`### Removed courses (${removed.length})`);
+              for (const c of removed) lines.push(`- [\`${c}\`](http://kurser.dtu.dk/course/${c}/info)`);
+              lines.push('');
+            }
+            if (semesters.length) {
+              lines.push(`### New grade semesters (${semesters.length})`);
+              for (const s of semesters) lines.push(`- \`${s.course}\` → [${s.url}](${s.url})`);
+              lines.push('');
+            }
+            lines.push('---');
+            lines.push('Verify the diff above. If it looks right, manually run the ' +
+                       '[**Update Course Data** workflow](../../actions/workflows/scrape.yml) ' +
+                       'to refresh the extension data.');
+            const body = lines.join('\n');
+
+            // Dedup: comment on existing open issue with the same label, else open a new one.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 10,
+            });
+
+            if (existing.data.length > 0) {
+              const issue = existing.data[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Follow-up check (${report.checked_at}):\n\n${body}`,
+              });
+              core.info(`Commented on existing issue #${issue.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+              core.info(`Opened issue #${created.data.number}`);
+            }

--- a/.github/workflows/check-course-updates.yml
+++ b/.github/workflows/check-course-updates.yml
@@ -71,22 +71,23 @@ jobs:
           python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
           import json, pathlib
           r = json.loads(pathlib.Path("check_report.json").read_text())
+          course_base = r.get('course_info_base_url', 'http://kurser.dtu.dk/course')
           print("## DTU course-data check")
           print()
           print(f"- Checked at: `{r['checked_at']}`")
           print(f"- Baseline courses: {r['baseline_course_count']} | Current: {r['current_course_count']}")
-          print(f"- Sample size for semester probe: {r['sample_size']}")
+          print(f"- Courses probed for semester links: {r.get('probed_course_count', r.get('sample_size', 0))}")
           print(f"- **Changes detected: {r['has_changes']}**")
           print()
           if r['added_courses']:
               print(f"### Added courses ({len(r['added_courses'])})")
               for c in r['added_courses']:
-                  print(f"- [{c}](http://kurser.dtu.dk/course/{c}/info)")
+                  print(f"- [{c}]({course_base}/{c}/info)")
               print()
           if r['removed_courses']:
               print(f"### Removed courses ({len(r['removed_courses'])})")
               for c in r['removed_courses']:
-                  print(f"- [{c}](http://kurser.dtu.dk/course/{c}/info)")
+                  print(f"- [{c}]({course_base}/{c}/info)")
               print()
           if r['new_semesters']:
               print(f"### New grade semesters ({len(r['new_semesters'])})")
@@ -140,6 +141,7 @@ jobs:
             const added = report.added_courses || [];
             const removed = report.removed_courses || [];
             const semesters = report.new_semesters || [];
+            const courseBase = report.course_info_base_url || 'http://kurser.dtu.dk/course';
 
             const title = `Weekly check: ${added.length} new course(s), ` +
                           `${removed.length} removed, ${semesters.length} new semester(s) (${date})`;
@@ -148,16 +150,16 @@ jobs:
             lines.push(`Automated weekly check detected new data on kurser.dtu.dk at \`${report.checked_at}\`.`);
             lines.push('');
             lines.push(`- Baseline courses: **${report.baseline_course_count}** · Current: **${report.current_course_count}**`);
-            lines.push(`- Sample size for semester probe: **${report.sample_size}**`);
+            lines.push(`- Courses probed for semester links: **${report.probed_course_count ?? report.sample_size ?? 0}**`);
             lines.push('');
             if (added.length) {
               lines.push(`### Added courses (${added.length})`);
-              for (const c of added) lines.push(`- [\`${c}\`](http://kurser.dtu.dk/course/${c}/info)`);
+              for (const c of added) lines.push(`- [\`${c}\`](${courseBase}/${c}/info)`);
               lines.push('');
             }
             if (removed.length) {
               lines.push(`### Removed courses (${removed.length})`);
-              for (const c of removed) lines.push(`- [\`${c}\`](http://kurser.dtu.dk/course/${c}/info)`);
+              for (const c of removed) lines.push(`- [\`${c}\`](${courseBase}/${c}/info)`);
               lines.push('');
             }
             if (semesters.length) {

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -57,4 +57,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Auto-update course data [skip ci]"
-          file_pattern: "extension/db/data.js extension/db.html extension/js/init_table.js"
+          file_pattern: "data/coursenumbers.txt data/coursedic.json extension/db/data.js extension/db.html extension/js/init_table.js"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,9 @@ dtu-validate coursedic.json
 # Generate extension data files
 dtu-analyze extension
 
+# Lightweight weekly probe — diff course list + sample new semesters, write check_report.json
+dtu-check-updates
+
 # Run tests
 pytest
 ```
@@ -177,6 +180,16 @@ The system follows a strict sequential pipeline:
    - Uses CLI tools for all pipeline steps
    - Manual trigger only (workflow_dispatch)
    - Commits updated data files
+
+7. **Weekly Update Check** ([.github/workflows/check-course-updates.yml](.github/workflows/check-course-updates.yml))
+   - Cheap probe that runs Sundays at 07:00 UTC (~09:00 Copenhagen)
+   - Calls `dtu-check-updates`: diffs the live course-number list against
+     `source-code/coursenumbers.txt` and probes a sample of active courses
+     for new grade semesters not in `source-code/coursedic.json`
+   - On change, opens (or comments on) a `course-data-update` issue with
+     diff + clickable links so the user can verify and manually trigger
+     the **Update Course Data** workflow
+   - Never runs the scraper itself — by design
 
 ## Code Style — STRICT
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ dtu-validate coursedic.json
 # Generate extension data files
 dtu-analyze extension
 
-# Lightweight weekly probe — diff course list + sample new semesters, write check_report.json
+# Lightweight weekly probe — diff course list + probe new semesters, write check_report.json
 dtu-check-updates
 
 # Run tests
@@ -184,8 +184,8 @@ The system follows a strict sequential pipeline:
 7. **Weekly Update Check** ([.github/workflows/check-course-updates.yml](.github/workflows/check-course-updates.yml))
    - Cheap probe that runs Sundays at 07:00 UTC (~09:00 Copenhagen)
    - Calls `dtu-check-updates`: diffs the live course-number list against
-     `source-code/coursenumbers.txt` and probes a sample of active courses
-     for new grade semesters not in `source-code/coursedic.json`
+     `data/coursenumbers.txt` and probes active courses
+     for new grade semesters not in `data/coursedic.json`
    - On change, opens (or comments on) a `course-data-update` issue with
      diff + clickable links so the user can verify and manually trigger
      the **Update Course Data** workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dtu-scrape = "dtu_analyzer.scrapers.async_scraper:main"
 dtu-scrape-threaded = "dtu_analyzer.scrapers.threaded_scraper:main"
 dtu-validate = "dtu_analyzer.validation.validator:main"
 dtu-analyze = "dtu_analyzer.analysis.analyzer:main"
+dtu-check-updates = "dtu_analyzer.scripts.check_for_updates:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
             "dtu-scrape-threaded=dtu_analyzer.scrapers.threaded_scraper:main",
             "dtu-validate=dtu_analyzer.validation.validator:main",
             "dtu-analyze=dtu_analyzer.analysis.analyzer:main",
+            "dtu-check-updates=dtu_analyzer.scripts.check_for_updates:main",
         ],
     },
     keywords="dtu education scraper grades courses denmark university",

--- a/src/dtu_analyzer/scripts/check_for_updates.py
+++ b/src/dtu_analyzer/scripts/check_for_updates.py
@@ -8,9 +8,8 @@ Cheap probe that does NOT scrape grades. It compares:
 2. Current active courses' grade-page URLs against the URLs already stored
    in ``data/coursedic.json`` (new semesters).
 
-Writes ``check_report.json`` in the repo root and always exits 0 (the
-calling workflow branches on the JSON, not the exit status). The only
-exception is auth/setup failure, which exits non-zero.
+Writes ``check_report.json`` in the repo root whenever possible. Exits non-zero
+for setup/probe failures while still preserving any course-list diff in the report.
 """
 
 import asyncio
@@ -53,6 +52,7 @@ def resolve_baseline_file(primary: Path, legacy: Path) -> Path:
     if legacy.exists():
         logger.warning(f"{primary} missing; falling back to legacy baseline {legacy}.")
         return legacy
+    logger.error(f"No baseline found. Checked {primary} and {legacy}.")
     return primary
 
 
@@ -160,7 +160,7 @@ async def fetch_grade_links_for_course(
                     logger.warning(f"HTTP {resp.status} for {url}")
                     return course_n, set()
                 html = await resp.text()
-        except Exception as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as e:
             logger.warning(f"Failed to fetch {url}: {e}")
             return course_n, set()
 
@@ -195,10 +195,13 @@ async def probe_new_semesters(
     semaphore = asyncio.Semaphore(MAX_CONCURRENT)
 
     new_semesters: list[dict] = []
+    courses_with_grade_links = 0
     async with aiohttp.ClientSession(connector=connector, cookies=cookies, headers=headers) as session:
         tasks = [fetch_grade_links_for_course(session, semaphore, c) for c in probe_courses]
         for coro in asyncio.as_completed(tasks):
             course_n, found_urls = await coro
+            if found_urls:
+                courses_with_grade_links += 1
             baseline = existing_grade_urls(coursedic, course_n)
             # Compare normalized — baseline urls in coursedic may be stored
             # with or without scheme; normalize both sides.
@@ -206,12 +209,36 @@ async def probe_new_semesters(
             for url in sorted(found_urls - baseline_norm):
                 new_semesters.append({'course': course_n, 'url': url})
                 logger.info(f"New semester for {course_n}: {url}")
+    if probe_courses and courses_with_grade_links == 0:
+        raise RuntimeError("No grade links found for any probed course; session cookie may be stale.")
     return sorted(new_semesters, key=lambda item: (item['course'], item['url']))
 
 
 def write_report(report: dict) -> None:
-    REPORT_FILE.write_text(json.dumps(report, indent=2, sort_keys=True))
+    try:
+        REPORT_FILE.write_text(json.dumps(report, indent=2, sort_keys=True))
+    except (OSError, TypeError) as e:
+        logger.error(f"Failed to write report to {REPORT_FILE}: {e}")
+        raise
     logger.info(f"Wrote report to {REPORT_FILE}")
+
+
+def base_report(**overrides) -> dict:
+    """Create a report with stable defaults for workflow consumers."""
+    report = {
+        'has_changes': False,
+        'added_courses': [],
+        'removed_courses': [],
+        'new_semesters': [],
+        'checked_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'sample_size': 0,
+        'probed_course_count': 0,
+        'baseline_course_count': 0,
+        'current_course_count': 0,
+        'course_info_base_url': f"{BASE_URL}/course",
+    }
+    report.update(overrides)
+    return report
 
 
 def main() -> int:
@@ -219,19 +246,27 @@ def main() -> int:
 
     # Read the committed baseline before refreshing data/coursenumbers.txt.
     baseline_numbers_file = resolve_baseline_file(BASELINE_NUMBERS_FILE, LEGACY_NUMBERS_FILE)
+    baseline_missing = not baseline_numbers_file.exists()
     baseline = load_baseline_course_numbers(baseline_numbers_file)
 
     # Step 1: refresh course-number list (writes data/coursenumbers.txt).
     if not get_course_numbers():
         logger.error("Failed to fetch current course numbers; aborting.")
+        write_report(base_report(check_failed=True, failure_reason='course_number_refresh_failed'))
         return 1
 
     current = load_current_course_numbers()
     if not current:
         logger.error("No current course numbers found after refresh; aborting.")
+        write_report(base_report(check_failed=True, failure_reason='current_course_numbers_missing'))
         return 1
-    added = sorted(current - baseline)
-    removed = sorted(baseline - current)
+    if baseline_missing:
+        added = []
+        removed = []
+        logger.error("Course-number baseline missing; suppressing added/removed diff to avoid noisy alerts.")
+    else:
+        added = sorted(current - baseline)
+        removed = sorted(baseline - current)
     logger.info(
         f"Course list diff: {len(added)} added, {len(removed)} removed "
         f"(baseline={len(baseline)}, current={len(current)})."
@@ -258,25 +293,24 @@ def main() -> int:
             if probe_courses:
                 try:
                     new_semesters = asyncio.run(probe_new_semesters(probe_courses, coursedic))
-                except RuntimeError as e:
+                except Exception as e:
                     probe_error = str(e)
                     logger.error(probe_error)
     else:
         logger.warning(f"{baseline_coursedic_file} missing; skipping semester probe.")
 
     has_changes = bool(added or removed or new_semesters)
-    report = {
-        'has_changes': has_changes,
-        'added_courses': added,
-        'removed_courses': removed,
-        'new_semesters': new_semesters,
-        'checked_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-        'sample_size': len(probe_courses),
-        'probed_course_count': len(probe_courses),
-        'baseline_course_count': len(baseline),
-        'current_course_count': len(current),
-        'course_info_base_url': f"{BASE_URL}/course",
-    }
+    report = base_report(
+        has_changes=has_changes,
+        added_courses=added,
+        removed_courses=removed,
+        new_semesters=new_semesters,
+        sample_size=len(probe_courses),
+        probed_course_count=len(probe_courses),
+        baseline_course_count=len(baseline),
+        current_course_count=len(current),
+        baseline_missing=baseline_missing,
+    )
     if probe_error:
         report['probe_error'] = probe_error
     write_report(report)

--- a/src/dtu_analyzer/scripts/check_for_updates.py
+++ b/src/dtu_analyzer/scripts/check_for_updates.py
@@ -4,9 +4,9 @@ Weekly DTU course-data change detector.
 Cheap probe that does NOT scrape grades. It compares:
 
 1. The current course-number list on kurser.dtu.dk against the committed
-   baseline at ``source-code/coursenumbers.txt`` (added/removed courses).
-2. A small sample of active courses' grade-page URLs against the URLs
-   already stored in ``source-code/coursedic.json`` (new semesters).
+   baseline at ``data/coursenumbers.txt`` (added/removed courses).
+2. Current active courses' grade-page URLs against the URLs already stored
+   in ``data/coursedic.json`` (new semesters).
 
 Writes ``check_report.json`` in the repo root and always exits 0 (the
 calling workflow branches on the JSON, not the exit status). The only
@@ -20,6 +20,7 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import aiohttp
 from bs4 import BeautifulSoup
@@ -34,21 +35,33 @@ BASE_URL = config.scraper.base_url
 TIMEOUT = config.scraper.timeout
 MAX_CONCURRENT = config.scraper.max_concurrent
 
-DEFAULT_SAMPLE_SIZE = int(os.getenv('CHECK_SAMPLE_SIZE', '8'))
 REPORT_FILE = config.paths.root_dir / 'check_report.json'
+GRADE_PATH_RE = re.compile(r"^/Histogram/\d+/\d{5}/[^/?#]+$")
 
-# The committed baselines (under source-code/, NOT data/, which holds the
-# freshly produced files from the current run).
-BASELINE_NUMBERS_FILE = config.paths.root_dir / 'source-code' / 'coursenumbers.txt'
-BASELINE_COURSEDIC_FILE = config.paths.root_dir / 'source-code' / 'coursedic.json'
+# The committed baselines updated by the full scrape workflow. Keep legacy
+# source-code fallbacks so the first run after this change still has a baseline.
+BASELINE_NUMBERS_FILE = config.paths.course_numbers_file
+BASELINE_COURSEDIC_FILE = config.paths.course_data_file
+LEGACY_NUMBERS_FILE = config.paths.root_dir / 'source-code' / 'coursenumbers.txt'
+LEGACY_COURSEDIC_FILE = config.paths.root_dir / 'source-code' / 'coursedic.json'
 
 
-def load_baseline_course_numbers() -> set[str]:
+def resolve_baseline_file(primary: Path, legacy: Path) -> Path:
+    """Use the updated data baseline when present, otherwise a legacy fallback."""
+    if primary.exists():
+        return primary
+    if legacy.exists():
+        logger.warning(f"{primary} missing; falling back to legacy baseline {legacy}.")
+        return legacy
+    return primary
+
+
+def load_baseline_course_numbers(path: Path) -> set[str]:
     """Read the comma-separated committed baseline of course numbers."""
-    if not BASELINE_NUMBERS_FILE.exists():
-        logger.warning(f"Baseline {BASELINE_NUMBERS_FILE} missing; treating as empty.")
+    if not path.exists():
+        logger.warning(f"Baseline {path} missing; treating as empty.")
         return set()
-    raw = BASELINE_NUMBERS_FILE.read_text().strip()
+    raw = path.read_text().strip()
     if not raw:
         return set()
     return {n.strip() for n in raw.split(',') if n.strip()}
@@ -57,31 +70,55 @@ def load_baseline_course_numbers() -> set[str]:
 def load_current_course_numbers() -> set[str]:
     """Read the freshly produced course-numbers file from this run."""
     path = config.paths.course_numbers_file
+    if not path.exists():
+        logger.error(f"Expected current course numbers at {path}, but the file is missing.")
+        return set()
     raw = path.read_text().strip()
     return {n.strip() for n in raw.split(',') if n.strip()}
 
 
-def pick_sample(coursedic: dict, size: int) -> list[str]:
-    """Pick the N courses with the most recent-semester participants.
+def get_probe_limit() -> int | None:
+    """Optional cap for diagnostic runs; by default, probe all active courses."""
+    raw = os.getenv('CHECK_PROBE_LIMIT') or os.getenv('CHECK_SAMPLE_SIZE')
+    if not raw:
+        return None
+    try:
+        limit = int(raw)
+    except ValueError:
+        logger.warning(f"Invalid probe limit {raw!r}; probing all eligible courses.")
+        return None
+    return limit if limit > 0 else None
 
-    Sampling by recent activity keeps the probe meaningful — obscure or
-    retired courses rarely get new semester data.
-    """
+
+def max_participants(data: dict) -> int:
+    """Highest participants count in stored grade entries, used for capped probes."""
+    grades = data.get('grades') or []
+    counts: list[int] = []
+    for grade in grades:
+        if not isinstance(grade, dict):
+            continue
+        try:
+            counts.append(int(grade.get('participants') or 0))
+        except (TypeError, ValueError):
+            continue
+    return max(counts, default=0)
+
+
+def select_probe_courses(
+    coursedic: dict,
+    current_courses: set[str],
+    limit: int | None = None,
+) -> list[str]:
+    """Pick current courses with baseline grades, optionally capped by activity."""
     scored: list[tuple[int, str]] = []
     for course_n, data in coursedic.items():
-        grades = data.get('grades') or []
-        if not grades:
+        if course_n not in current_courses or not (data.get('grades') or []):
             continue
-        # `grades` is a list of semester dicts; treat the first entry as
-        # the most recent (matches how the scraper stores them).
-        recent = grades[0]
-        try:
-            participants = int(recent.get('participants') or 0)
-        except (TypeError, ValueError):
-            participants = 0
-        scored.append((participants, course_n))
-    scored.sort(reverse=True)
-    return [c for _, c in scored[:size]]
+        scored.append((max_participants(data), course_n))
+    if limit is None:
+        return sorted(course_n for _, course_n in scored)
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return [course_n for _, course_n in scored[:limit]]
 
 
 def existing_grade_urls(coursedic: dict, course_n: str) -> set[str]:
@@ -95,13 +132,18 @@ def existing_grade_urls(coursedic: dict, course_n: str) -> set[str]:
 
 
 def normalize_grade_href(href: str) -> str:
-    """Turn a relative or absolute karakterer href into an absolute URL."""
-    href = href.strip()
-    if href.startswith('http://') or href.startswith('https://'):
-        return href
-    if not href.startswith('/'):
-        href = '/' + href
-    return f"{BASE_URL}{href}"
+    """Turn a relative or absolute karakterer href into a canonical URL."""
+    absolute = urljoin(f"{BASE_URL}/", href.strip())
+    parsed = urlsplit(absolute)
+    scheme = 'http' if parsed.netloc.lower() == 'karakterer.dtu.dk' else parsed.scheme.lower()
+    netloc = parsed.netloc.lower()
+    return urlunsplit((scheme, netloc, parsed.path, parsed.query, ''))
+
+
+def is_grade_histogram_href(href: str) -> bool:
+    """Return whether an href points to a DTU grade histogram page."""
+    parsed = urlsplit(urljoin(f"{BASE_URL}/", href.strip()))
+    return parsed.netloc.lower() == 'karakterer.dtu.dk' and bool(GRADE_PATH_RE.fullmatch(parsed.path))
 
 
 async def fetch_grade_links_for_course(
@@ -126,21 +168,22 @@ async def fetch_grade_links_for_course(
     found: set[str] = set()
     for a in soup.find_all('a'):
         href = a.get('href')
-        if href and 'karakterer' in href:
+        if href and is_grade_histogram_href(href):
             found.add(normalize_grade_href(href))
     return course_n, found
 
 
 async def probe_new_semesters(
-    sample_courses: list[str],
+    probe_courses: list[str],
     coursedic: dict,
 ) -> list[dict]:
-    """For each sampled course, return any grade URLs not in the baseline."""
+    """For each probed course, return any grade URLs not in the baseline."""
     try:
         session_cookie = config.paths.secret_file.read_text().strip()
     except FileNotFoundError:
-        logger.error(f"{config.paths.secret_file} missing; cannot probe semesters.")
-        return []
+        raise RuntimeError(f"{config.paths.secret_file} missing; cannot probe semesters.")
+    if not session_cookie:
+        raise RuntimeError(f"{config.paths.secret_file} is empty; cannot probe semesters.")
 
     cookies = {'ASP.NET_SessionId': session_cookie}
     headers = {
@@ -153,7 +196,7 @@ async def probe_new_semesters(
 
     new_semesters: list[dict] = []
     async with aiohttp.ClientSession(connector=connector, cookies=cookies, headers=headers) as session:
-        tasks = [fetch_grade_links_for_course(session, semaphore, c) for c in sample_courses]
+        tasks = [fetch_grade_links_for_course(session, semaphore, c) for c in probe_courses]
         for coro in asyncio.as_completed(tasks):
             course_n, found_urls = await coro
             baseline = existing_grade_urls(coursedic, course_n)
@@ -163,7 +206,7 @@ async def probe_new_semesters(
             for url in sorted(found_urls - baseline_norm):
                 new_semesters.append({'course': course_n, 'url': url})
                 logger.info(f"New semester for {course_n}: {url}")
-    return new_semesters
+    return sorted(new_semesters, key=lambda item: (item['course'], item['url']))
 
 
 def write_report(report: dict) -> None:
@@ -174,13 +217,19 @@ def write_report(report: dict) -> None:
 def main() -> int:
     logger.info("Starting weekly DTU course-data check.")
 
+    # Read the committed baseline before refreshing data/coursenumbers.txt.
+    baseline_numbers_file = resolve_baseline_file(BASELINE_NUMBERS_FILE, LEGACY_NUMBERS_FILE)
+    baseline = load_baseline_course_numbers(baseline_numbers_file)
+
     # Step 1: refresh course-number list (writes data/coursenumbers.txt).
     if not get_course_numbers():
         logger.error("Failed to fetch current course numbers; aborting.")
         return 1
 
-    baseline = load_baseline_course_numbers()
     current = load_current_course_numbers()
+    if not current:
+        logger.error("No current course numbers found after refresh; aborting.")
+        return 1
     added = sorted(current - baseline)
     removed = sorted(baseline - current)
     logger.info(
@@ -188,21 +237,32 @@ def main() -> int:
         f"(baseline={len(baseline)}, current={len(current)})."
     )
 
-    # Step 2: load coursedic.json baseline and pick a sample for probing.
+    # Step 2: load coursedic.json baseline and pick courses for probing.
     new_semesters: list[dict] = []
-    sample: list[str] = []
-    if BASELINE_COURSEDIC_FILE.exists():
+    probe_courses: list[str] = []
+    probe_error = None
+    baseline_coursedic_file = resolve_baseline_file(BASELINE_COURSEDIC_FILE, LEGACY_COURSEDIC_FILE)
+    if baseline_coursedic_file.exists():
         try:
-            coursedic = json.loads(BASELINE_COURSEDIC_FILE.read_text())
+            coursedic = json.loads(baseline_coursedic_file.read_text())
         except json.JSONDecodeError as e:
-            logger.error(f"Could not parse {BASELINE_COURSEDIC_FILE}: {e}")
+            logger.error(f"Could not parse {baseline_coursedic_file}: {e}")
             coursedic = {}
         if coursedic:
-            sample = pick_sample(coursedic, DEFAULT_SAMPLE_SIZE)
-            logger.info(f"Probing {len(sample)} sample courses for new semesters: {sample}")
-            new_semesters = asyncio.run(probe_new_semesters(sample, coursedic))
+            probe_limit = get_probe_limit()
+            probe_courses = select_probe_courses(coursedic, current, probe_limit)
+            if probe_limit is None:
+                logger.info(f"Probing all {len(probe_courses)} current courses with baseline grades.")
+            else:
+                logger.info(f"Probing {len(probe_courses)} capped courses for new semesters.")
+            if probe_courses:
+                try:
+                    new_semesters = asyncio.run(probe_new_semesters(probe_courses, coursedic))
+                except RuntimeError as e:
+                    probe_error = str(e)
+                    logger.error(probe_error)
     else:
-        logger.warning(f"{BASELINE_COURSEDIC_FILE} missing; skipping semester probe.")
+        logger.warning(f"{baseline_coursedic_file} missing; skipping semester probe.")
 
     has_changes = bool(added or removed or new_semesters)
     report = {
@@ -211,11 +271,18 @@ def main() -> int:
         'removed_courses': removed,
         'new_semesters': new_semesters,
         'checked_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-        'sample_size': len(sample),
+        'sample_size': len(probe_courses),
+        'probed_course_count': len(probe_courses),
         'baseline_course_count': len(baseline),
         'current_course_count': len(current),
+        'course_info_base_url': f"{BASE_URL}/course",
     }
+    if probe_error:
+        report['probe_error'] = probe_error
     write_report(report)
+
+    if probe_error:
+        return 1
 
     if has_changes:
         logger.info(

--- a/src/dtu_analyzer/scripts/check_for_updates.py
+++ b/src/dtu_analyzer/scripts/check_for_updates.py
@@ -1,0 +1,231 @@
+"""
+Weekly DTU course-data change detector.
+
+Cheap probe that does NOT scrape grades. It compares:
+
+1. The current course-number list on kurser.dtu.dk against the committed
+   baseline at ``source-code/coursenumbers.txt`` (added/removed courses).
+2. A small sample of active courses' grade-page URLs against the URLs
+   already stored in ``source-code/coursedic.json`` (new semesters).
+
+Writes ``check_report.json`` in the repo root and always exits 0 (the
+calling workflow branches on the JSON, not the exit status). The only
+exception is auth/setup failure, which exits non-zero.
+"""
+
+import asyncio
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import aiohttp
+from bs4 import BeautifulSoup
+
+from ..config import config
+from ..utils.logger import setup_logger
+from .get_course_numbers import get_course_numbers
+
+logger = setup_logger('check_updates', 'check_updates.log')
+
+BASE_URL = config.scraper.base_url
+TIMEOUT = config.scraper.timeout
+MAX_CONCURRENT = config.scraper.max_concurrent
+
+DEFAULT_SAMPLE_SIZE = int(os.getenv('CHECK_SAMPLE_SIZE', '8'))
+REPORT_FILE = config.paths.root_dir / 'check_report.json'
+
+# The committed baselines (under source-code/, NOT data/, which holds the
+# freshly produced files from the current run).
+BASELINE_NUMBERS_FILE = config.paths.root_dir / 'source-code' / 'coursenumbers.txt'
+BASELINE_COURSEDIC_FILE = config.paths.root_dir / 'source-code' / 'coursedic.json'
+
+
+def load_baseline_course_numbers() -> set[str]:
+    """Read the comma-separated committed baseline of course numbers."""
+    if not BASELINE_NUMBERS_FILE.exists():
+        logger.warning(f"Baseline {BASELINE_NUMBERS_FILE} missing; treating as empty.")
+        return set()
+    raw = BASELINE_NUMBERS_FILE.read_text().strip()
+    if not raw:
+        return set()
+    return {n.strip() for n in raw.split(',') if n.strip()}
+
+
+def load_current_course_numbers() -> set[str]:
+    """Read the freshly produced course-numbers file from this run."""
+    path = config.paths.course_numbers_file
+    raw = path.read_text().strip()
+    return {n.strip() for n in raw.split(',') if n.strip()}
+
+
+def pick_sample(coursedic: dict, size: int) -> list[str]:
+    """Pick the N courses with the most recent-semester participants.
+
+    Sampling by recent activity keeps the probe meaningful — obscure or
+    retired courses rarely get new semester data.
+    """
+    scored: list[tuple[int, str]] = []
+    for course_n, data in coursedic.items():
+        grades = data.get('grades') or []
+        if not grades:
+            continue
+        # `grades` is a list of semester dicts; treat the first entry as
+        # the most recent (matches how the scraper stores them).
+        recent = grades[0]
+        try:
+            participants = int(recent.get('participants') or 0)
+        except (TypeError, ValueError):
+            participants = 0
+        scored.append((participants, course_n))
+    scored.sort(reverse=True)
+    return [c for _, c in scored[:size]]
+
+
+def existing_grade_urls(coursedic: dict, course_n: str) -> set[str]:
+    """All grade-page URLs we already have stored for a given course."""
+    urls: set[str] = set()
+    for grade in coursedic.get(course_n, {}).get('grades', []) or []:
+        url = grade.get('url')
+        if url:
+            urls.add(url.strip())
+    return urls
+
+
+def normalize_grade_href(href: str) -> str:
+    """Turn a relative or absolute karakterer href into an absolute URL."""
+    href = href.strip()
+    if href.startswith('http://') or href.startswith('https://'):
+        return href
+    if not href.startswith('/'):
+        href = '/' + href
+    return f"{BASE_URL}{href}"
+
+
+async def fetch_grade_links_for_course(
+    session: aiohttp.ClientSession,
+    semaphore: asyncio.Semaphore,
+    course_n: str,
+) -> tuple[str, set[str]]:
+    """Fetch a course's info page and extract all karakterer links."""
+    url = f"{BASE_URL}/course/{course_n}/info"
+    async with semaphore:
+        try:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=TIMEOUT)) as resp:
+                if resp.status != 200:
+                    logger.warning(f"HTTP {resp.status} for {url}")
+                    return course_n, set()
+                html = await resp.text()
+        except Exception as e:
+            logger.warning(f"Failed to fetch {url}: {e}")
+            return course_n, set()
+
+    soup = BeautifulSoup(html, 'lxml')
+    found: set[str] = set()
+    for a in soup.find_all('a'):
+        href = a.get('href')
+        if href and 'karakterer' in href:
+            found.add(normalize_grade_href(href))
+    return course_n, found
+
+
+async def probe_new_semesters(
+    sample_courses: list[str],
+    coursedic: dict,
+) -> list[dict]:
+    """For each sampled course, return any grade URLs not in the baseline."""
+    try:
+        session_cookie = config.paths.secret_file.read_text().strip()
+    except FileNotFoundError:
+        logger.error(f"{config.paths.secret_file} missing; cannot probe semesters.")
+        return []
+
+    cookies = {'ASP.NET_SessionId': session_cookie}
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                      'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36',
+        'Accept-Encoding': 'gzip, deflate',
+    }
+    connector = aiohttp.TCPConnector(limit=MAX_CONCURRENT, limit_per_host=MAX_CONCURRENT)
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT)
+
+    new_semesters: list[dict] = []
+    async with aiohttp.ClientSession(connector=connector, cookies=cookies, headers=headers) as session:
+        tasks = [fetch_grade_links_for_course(session, semaphore, c) for c in sample_courses]
+        for coro in asyncio.as_completed(tasks):
+            course_n, found_urls = await coro
+            baseline = existing_grade_urls(coursedic, course_n)
+            # Compare normalized — baseline urls in coursedic may be stored
+            # with or without scheme; normalize both sides.
+            baseline_norm = {normalize_grade_href(u) for u in baseline}
+            for url in sorted(found_urls - baseline_norm):
+                new_semesters.append({'course': course_n, 'url': url})
+                logger.info(f"New semester for {course_n}: {url}")
+    return new_semesters
+
+
+def write_report(report: dict) -> None:
+    REPORT_FILE.write_text(json.dumps(report, indent=2, sort_keys=True))
+    logger.info(f"Wrote report to {REPORT_FILE}")
+
+
+def main() -> int:
+    logger.info("Starting weekly DTU course-data check.")
+
+    # Step 1: refresh course-number list (writes data/coursenumbers.txt).
+    if not get_course_numbers():
+        logger.error("Failed to fetch current course numbers; aborting.")
+        return 1
+
+    baseline = load_baseline_course_numbers()
+    current = load_current_course_numbers()
+    added = sorted(current - baseline)
+    removed = sorted(baseline - current)
+    logger.info(
+        f"Course list diff: {len(added)} added, {len(removed)} removed "
+        f"(baseline={len(baseline)}, current={len(current)})."
+    )
+
+    # Step 2: load coursedic.json baseline and pick a sample for probing.
+    new_semesters: list[dict] = []
+    sample: list[str] = []
+    if BASELINE_COURSEDIC_FILE.exists():
+        try:
+            coursedic = json.loads(BASELINE_COURSEDIC_FILE.read_text())
+        except json.JSONDecodeError as e:
+            logger.error(f"Could not parse {BASELINE_COURSEDIC_FILE}: {e}")
+            coursedic = {}
+        if coursedic:
+            sample = pick_sample(coursedic, DEFAULT_SAMPLE_SIZE)
+            logger.info(f"Probing {len(sample)} sample courses for new semesters: {sample}")
+            new_semesters = asyncio.run(probe_new_semesters(sample, coursedic))
+    else:
+        logger.warning(f"{BASELINE_COURSEDIC_FILE} missing; skipping semester probe.")
+
+    has_changes = bool(added or removed or new_semesters)
+    report = {
+        'has_changes': has_changes,
+        'added_courses': added,
+        'removed_courses': removed,
+        'new_semesters': new_semesters,
+        'checked_at': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'sample_size': len(sample),
+        'baseline_course_count': len(baseline),
+        'current_course_count': len(current),
+    }
+    write_report(report)
+
+    if has_changes:
+        logger.info(
+            f"Changes detected — added={len(added)} removed={len(removed)} "
+            f"new_semesters={len(new_semesters)}"
+        )
+    else:
+        logger.info("No changes detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_for_updates.py
+++ b/tests/test_check_for_updates.py
@@ -1,7 +1,5 @@
-"""Tests for the lightweight course-data update checker."""
-
-import json
 import asyncio
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,6 +13,13 @@ def test_resolve_baseline_file_prefers_updated_data_file(tmp_path: Path) -> None
     legacy_file.parent.mkdir()
     data_file.write_text("{}")
     legacy_file.write_text("{}")
+
+    assert checker.resolve_baseline_file(data_file, legacy_file) == data_file
+
+
+def test_resolve_baseline_file_returns_primary_when_both_missing(tmp_path: Path) -> None:
+    data_file = tmp_path / "data" / "coursedic.json"
+    legacy_file = tmp_path / "source-code" / "coursedic.json"
 
     assert checker.resolve_baseline_file(data_file, legacy_file) == data_file
 
@@ -92,6 +97,58 @@ def test_main_reports_probe_error_when_secret_is_missing(monkeypatch, tmp_path: 
     assert report["probed_course_count"] == 1
 
 
+def test_probe_new_semesters_rejects_empty_secret(monkeypatch, tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("")
+    monkeypatch.setattr(checker.config, "paths", SimpleNamespace(secret_file=secret))
+
+    try:
+        asyncio.run(checker.probe_new_semesters(["11111"], {"11111": {}}))
+    except RuntimeError as e:
+        assert "is empty" in str(e)
+    else:
+        raise AssertionError("Expected RuntimeError for empty secret")
+
+
+def test_probe_new_semesters_returns_empty_when_urls_are_in_baseline(monkeypatch, tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("session")
+    url = "http://karakterer.dtu.dk/Histogram/1/11111/Summer-2025"
+    monkeypatch.setattr(checker.config, "paths", SimpleNamespace(secret_file=secret))
+
+    async def fake_fetch(session, semaphore, course_n: str):
+        return course_n, {url}
+
+    monkeypatch.setattr(checker, "fetch_grade_links_for_course", fake_fetch)
+
+    result = asyncio.run(
+        checker.probe_new_semesters(
+            ["11111"],
+            {"11111": {"grades": [{"participants": 1, "url": url}]}},
+        )
+    )
+
+    assert result == []
+
+
+def test_probe_new_semesters_flags_all_empty_results_as_stale_cookie(monkeypatch, tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("session")
+    monkeypatch.setattr(checker.config, "paths", SimpleNamespace(secret_file=secret))
+
+    async def fake_fetch(session, semaphore, course_n: str):
+        return course_n, set()
+
+    monkeypatch.setattr(checker, "fetch_grade_links_for_course", fake_fetch)
+
+    try:
+        asyncio.run(checker.probe_new_semesters(["11111"], {"11111": {}}))
+    except RuntimeError as e:
+        assert "cookie may be stale" in str(e)
+    else:
+        raise AssertionError("Expected RuntimeError for empty probe results")
+
+
 def test_probe_new_semesters_returns_stable_order(monkeypatch, tmp_path: Path) -> None:
     secret = tmp_path / "secret.txt"
     secret.write_text("session")
@@ -108,6 +165,106 @@ def test_probe_new_semesters_returns_stable_order(monkeypatch, tmp_path: Path) -
         {"course": "11111", "url": "http://karakterer.dtu.dk/Histogram/1/11111/Summer-2025"},
         {"course": "22222", "url": "http://karakterer.dtu.dk/Histogram/1/22222/Summer-2025"},
     ]
+
+
+def test_main_happy_path_reports_changes_and_new_semesters(monkeypatch, tmp_path: Path) -> None:
+    course_numbers = tmp_path / "data" / "coursenumbers.txt"
+    coursedic = tmp_path / "data" / "coursedic.json"
+    report_file = tmp_path / "check_report.json"
+    new_url = "http://karakterer.dtu.dk/Histogram/1/11111/Winter-2026"
+    course_numbers.parent.mkdir()
+    course_numbers.write_text("11111")
+    coursedic.write_text(
+        json.dumps(
+            {
+                "11111": {
+                    "grades": [
+                        {
+                            "participants": 1,
+                            "url": "http://karakterer.dtu.dk/Histogram/1/11111/Summer-2025",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+
+    def refresh_course_numbers() -> bool:
+        course_numbers.write_text("11111,22222")
+        return True
+
+    async def fake_probe(probe_courses, baseline):
+        assert probe_courses == ["11111"]
+        return [{"course": "11111", "url": new_url}]
+
+    monkeypatch.setattr(checker, "BASELINE_NUMBERS_FILE", course_numbers)
+    monkeypatch.setattr(checker, "BASELINE_COURSEDIC_FILE", coursedic)
+    monkeypatch.setattr(checker, "LEGACY_NUMBERS_FILE", tmp_path / "missing-coursenumbers.txt")
+    monkeypatch.setattr(checker, "LEGACY_COURSEDIC_FILE", tmp_path / "missing-coursedic.json")
+    monkeypatch.setattr(checker, "REPORT_FILE", report_file)
+    monkeypatch.setattr(checker, "get_course_numbers", refresh_course_numbers)
+    monkeypatch.setattr(checker, "probe_new_semesters", fake_probe)
+    monkeypatch.setattr(
+        checker.config,
+        "paths",
+        SimpleNamespace(course_numbers_file=course_numbers, secret_file=tmp_path / "secret.txt"),
+    )
+
+    assert checker.main() == 0
+
+    report = json.loads(report_file.read_text())
+    assert report["has_changes"] is True
+    assert report["added_courses"] == ["22222"]
+    assert report["new_semesters"] == [{"course": "11111", "url": new_url}]
+
+
+def test_main_writes_failure_report_when_course_refresh_fails(monkeypatch, tmp_path: Path) -> None:
+    report_file = tmp_path / "check_report.json"
+    baseline = tmp_path / "data" / "coursenumbers.txt"
+    baseline.parent.mkdir()
+    baseline.write_text("11111")
+
+    monkeypatch.setattr(checker, "BASELINE_NUMBERS_FILE", baseline)
+    monkeypatch.setattr(checker, "LEGACY_NUMBERS_FILE", tmp_path / "missing-coursenumbers.txt")
+    monkeypatch.setattr(checker, "REPORT_FILE", report_file)
+    monkeypatch.setattr(checker, "get_course_numbers", lambda: False)
+
+    assert checker.main() == 1
+
+    report = json.loads(report_file.read_text())
+    assert report["check_failed"] is True
+    assert report["failure_reason"] == "course_number_refresh_failed"
+
+
+def test_main_suppresses_course_diff_when_baseline_is_missing(monkeypatch, tmp_path: Path) -> None:
+    course_numbers = tmp_path / "data" / "coursenumbers.txt"
+    coursedic = tmp_path / "data" / "coursedic.json"
+    report_file = tmp_path / "check_report.json"
+    course_numbers.parent.mkdir()
+    coursedic.write_text("{}")
+
+    def refresh_course_numbers() -> bool:
+        course_numbers.write_text("11111,22222")
+        return True
+
+    monkeypatch.setattr(checker, "BASELINE_NUMBERS_FILE", tmp_path / "missing-coursenumbers.txt")
+    monkeypatch.setattr(checker, "BASELINE_COURSEDIC_FILE", coursedic)
+    monkeypatch.setattr(checker, "LEGACY_NUMBERS_FILE", tmp_path / "missing-legacy-coursenumbers.txt")
+    monkeypatch.setattr(checker, "LEGACY_COURSEDIC_FILE", tmp_path / "missing-legacy-coursedic.json")
+    monkeypatch.setattr(checker, "REPORT_FILE", report_file)
+    monkeypatch.setattr(checker, "get_course_numbers", refresh_course_numbers)
+    monkeypatch.setattr(
+        checker.config,
+        "paths",
+        SimpleNamespace(course_numbers_file=course_numbers, secret_file=tmp_path / "secret.txt"),
+    )
+
+    assert checker.main() == 0
+
+    report = json.loads(report_file.read_text())
+    assert report["baseline_missing"] is True
+    assert report["has_changes"] is False
+    assert report["added_courses"] == []
 
 
 def test_main_reads_course_number_baseline_before_refresh(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_check_for_updates.py
+++ b/tests/test_check_for_updates.py
@@ -1,0 +1,141 @@
+"""Tests for the lightweight course-data update checker."""
+
+import json
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import dtu_analyzer.scripts.check_for_updates as checker
+
+
+def test_resolve_baseline_file_prefers_updated_data_file(tmp_path: Path) -> None:
+    data_file = tmp_path / "data" / "coursedic.json"
+    legacy_file = tmp_path / "source-code" / "coursedic.json"
+    data_file.parent.mkdir()
+    legacy_file.parent.mkdir()
+    data_file.write_text("{}")
+    legacy_file.write_text("{}")
+
+    assert checker.resolve_baseline_file(data_file, legacy_file) == data_file
+
+
+def test_select_probe_courses_uses_all_current_courses_by_default() -> None:
+    coursedic = {
+        "11111": {"grades": [{"participants": 2}]},
+        "22222": {"grades": [{"participants": 200}]},
+        "33333": {"grades": []},
+        "44444": {"grades": [{"participants": 100}]},
+    }
+
+    selected = checker.select_probe_courses(coursedic, {"11111", "22222", "33333"})
+
+    assert selected == ["11111", "22222"]
+
+
+def test_select_probe_courses_can_be_capped_by_recent_activity() -> None:
+    coursedic = {
+        "11111": {"grades": [{"participants": 2}]},
+        "22222": {"grades": [{"participants": 1}, {"participants": 200}]},
+        "33333": {"grades": [{"participants": 100}]},
+    }
+
+    selected = checker.select_probe_courses(coursedic, set(coursedic), limit=2)
+
+    assert selected == ["22222", "33333"]
+
+
+def test_normalize_grade_href_avoids_scheme_false_positives() -> None:
+    expected = "http://karakterer.dtu.dk/Histogram/1/01001/Summer-2025"
+
+    assert checker.normalize_grade_href(expected) == expected
+    assert checker.normalize_grade_href(expected.replace("http://", "https://")) == expected
+    assert checker.normalize_grade_href("//karakterer.dtu.dk/Histogram/1/01001/Summer-2025") == expected
+
+
+def test_grade_href_filter_only_accepts_histogram_pages() -> None:
+    assert checker.is_grade_histogram_href("https://karakterer.dtu.dk/Histogram/1/01001/Summer-2025")
+    assert not checker.is_grade_histogram_href("https://example.com/?ref=karakterer")
+    assert not checker.is_grade_histogram_href("https://karakterer.dtu.dk/not-histogram/01001")
+
+
+def test_load_current_course_numbers_returns_empty_when_missing(monkeypatch, tmp_path: Path) -> None:
+    missing = tmp_path / "data" / "coursenumbers.txt"
+    monkeypatch.setattr(checker.config, "paths", SimpleNamespace(course_numbers_file=missing))
+
+    assert checker.load_current_course_numbers() == set()
+
+
+def test_main_reports_probe_error_when_secret_is_missing(monkeypatch, tmp_path: Path) -> None:
+    course_numbers = tmp_path / "data" / "coursenumbers.txt"
+    coursedic = tmp_path / "data" / "coursedic.json"
+    report_file = tmp_path / "check_report.json"
+    course_numbers.parent.mkdir()
+    course_numbers.write_text("11111")
+    coursedic.write_text(json.dumps({"11111": {"grades": [{"participants": 1, "url": "x"}]}}))
+
+    monkeypatch.setattr(checker, "BASELINE_NUMBERS_FILE", course_numbers)
+    monkeypatch.setattr(checker, "BASELINE_COURSEDIC_FILE", coursedic)
+    monkeypatch.setattr(checker, "LEGACY_NUMBERS_FILE", tmp_path / "missing-coursenumbers.txt")
+    monkeypatch.setattr(checker, "LEGACY_COURSEDIC_FILE", tmp_path / "missing-coursedic.json")
+    monkeypatch.setattr(checker, "REPORT_FILE", report_file)
+    monkeypatch.setattr(checker, "get_course_numbers", lambda: True)
+    monkeypatch.setattr(
+        checker.config,
+        "paths",
+        SimpleNamespace(course_numbers_file=course_numbers, secret_file=tmp_path / "missing-secret.txt"),
+    )
+
+    assert checker.main() == 1
+
+    report = json.loads(report_file.read_text())
+    assert "probe_error" in report
+    assert report["probed_course_count"] == 1
+
+
+def test_probe_new_semesters_returns_stable_order(monkeypatch, tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("session")
+    monkeypatch.setattr(checker.config, "paths", SimpleNamespace(secret_file=secret))
+
+    async def fake_fetch(session, semaphore, course_n: str):
+        return course_n, {f"http://karakterer.dtu.dk/Histogram/1/{course_n}/Summer-2025"}
+
+    monkeypatch.setattr(checker, "fetch_grade_links_for_course", fake_fetch)
+
+    result = asyncio.run(checker.probe_new_semesters(["22222", "11111"], {"11111": {}, "22222": {}}))
+
+    assert result == [
+        {"course": "11111", "url": "http://karakterer.dtu.dk/Histogram/1/11111/Summer-2025"},
+        {"course": "22222", "url": "http://karakterer.dtu.dk/Histogram/1/22222/Summer-2025"},
+    ]
+
+
+def test_main_reads_course_number_baseline_before_refresh(monkeypatch, tmp_path: Path) -> None:
+    course_numbers = tmp_path / "data" / "coursenumbers.txt"
+    coursedic = tmp_path / "data" / "coursedic.json"
+    report_file = tmp_path / "check_report.json"
+    course_numbers.parent.mkdir()
+    course_numbers.write_text("11111")
+    coursedic.write_text("{}")
+
+    def refresh_course_numbers() -> bool:
+        course_numbers.write_text("11111,22222")
+        return True
+
+    monkeypatch.setattr(checker, "BASELINE_NUMBERS_FILE", course_numbers)
+    monkeypatch.setattr(checker, "BASELINE_COURSEDIC_FILE", coursedic)
+    monkeypatch.setattr(checker, "LEGACY_NUMBERS_FILE", tmp_path / "missing-coursenumbers.txt")
+    monkeypatch.setattr(checker, "LEGACY_COURSEDIC_FILE", tmp_path / "missing-coursedic.json")
+    monkeypatch.setattr(checker, "REPORT_FILE", report_file)
+    monkeypatch.setattr(checker, "get_course_numbers", refresh_course_numbers)
+    monkeypatch.setattr(
+        checker.config,
+        "paths",
+        SimpleNamespace(course_numbers_file=course_numbers, secret_file=tmp_path / "secret.txt"),
+    )
+
+    assert checker.main() == 0
+
+    report = json.loads(report_file.read_text())
+    assert report["added_courses"] == ["22222"]
+    assert report["removed_courses"] == []


### PR DESCRIPTION
Adds a cheap Sunday-morning probe that detects new courses and new grade semesters on kurser.dtu.dk without running the full scrape pipeline.

- New `dtu-check-updates` CLI: diffs the live course list against source-code/coursenumbers.txt and probes a sample of active courses for new karakterer URLs not in source-code/coursedic.json. Writes check_report.json.
- New workflow `.github/workflows/check-course-updates.yml`: cron at 07:00 UTC Sunday (~09:00 Copenhagen), authenticates with the existing DTU_USERNAME/DTU_PASSWORD secrets, runs the check, writes a job summary, and opens (or comments on) a `course-data-update` GitHub issue with diff + clickable links so the user can verify and manually trigger the existing Update Course Data workflow.

https://claude.ai/code/session_01HGdSVQyTtcQYFeurCcZdZH